### PR TITLE
Investigate nav bar shift on project page

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -72,3 +72,15 @@
 .prose-styles {
   @apply text-sm prose text-neutral-600 dark:text-neutral-600 prose-a:font-normal prose-a:text-blue-400 hover:prose-a:text-black prose-h1:text-black prose-img:border-2  prose-img:bg-neutral-50 dark:prose-img:bg-neutral-800 prose-img:border-transparent dark:prose-img:invert prose-h2:text-black prose-h2:font-semibold prose-p:text-sm prose-pre:font-mono max-w-none prose-pre:rounded-none prose-headings:font-display;
 }
+
+/* Reserve space for vertical scrollbar to prevent layout shift between pages */
+html {
+  scrollbar-gutter: stable;
+}
+
+/* Fallback for browsers without scrollbar-gutter support */
+@supports not (scrollbar-gutter: stable) {
+  html {
+    overflow-y: scroll;
+  }
+}


### PR DESCRIPTION
Add global CSS to reserve scrollbar space, preventing layout shifts on page navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6142c0c-8ce6-4ccc-a7e0-8b3b11c44e18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6142c0c-8ce6-4ccc-a7e0-8b3b11c44e18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

